### PR TITLE
Add mapDbName commandline option

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Or use the shortcurt `cdbb`.
 
 When `SOURCE` is omitted, the current directory will be used.
 `options.index` is always true.
-`OPTIONS` can be '--concurrency', `--multipart` or `--watch`, see above.
+`OPTIONS` can be '--concurrency', `--multipart`, `--watch` or `--mapDbName='{"old-name": "new-name"}'`, see above.
 
 ### CLI Example
 

--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,7 @@ var bootstrap = require('./')
 
 var options = minimist(process.argv.slice(2), {
   boolean: ['multipart', 'watch'],
-  string: 'concurrency'
+  string: ['concurrency', 'mapDbName']
 })
 
 if (!options._.length) {
@@ -14,6 +14,10 @@ if (!options._.length) {
 
 var url = options._[0]
 var source = options._[1] || process.cwd()
+
+if (options.mapDbName) {
+  options.mapDbName = JSON.parse(options.mapDbName)
+}
 
 bootstrap(url, source, options, function (error, response) {
   if (error) return console.error(error)

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -1,0 +1,15 @@
+var exec = require('child_process').exec
+var test = require('tap').test
+var helper = require('./helper')
+
+test('cli', function (t) {
+  var dbName = 'test-cli-bootstrap'
+  var mapDbName = JSON.stringify({'test-couchdb-bootstrap': dbName})
+  var cmd = ['./cli.js', helper.url, helper.source, '--mapDbName=\'' + mapDbName + '\'']
+  exec(cmd.join(' '), function (err, stdout) {
+    t.error(err)
+    var j = JSON.parse(stdout)
+    t.ok(!!j.push[dbName])
+    t.end()
+  })
+})


### PR DESCRIPTION
Add `mapDbName` to the cli options. Its a k/v option and expects the value to be a json string, e.g: `--mapDbName='{"foo-db": "bar-db"}'`.

This also adds a test for the cli.